### PR TITLE
Adding null check to aspnetSubPath

### DIFF
--- a/ServiceStack.Api.Postman/PostmanMetadataHandler.cs
+++ b/ServiceStack.Api.Postman/PostmanMetadataHandler.cs
@@ -205,7 +205,7 @@ namespace ServiceStack.Api.Postman
 
             if (serviceStackUrl.Equals(aspnetSubPath))
                 return serviceStackUrl;
-            if (serviceStackUrl.StartsWith(aspnetSubPath))
+            if (aspnetSubPath != null && serviceStackUrl.StartsWith(aspnetSubPath))
                 return serviceStackUrl;
 
             string newUrl;


### PR DESCRIPTION
Adding null check to aspnetSubPath to avoid exception when calling StartsWith(null)
